### PR TITLE
Add multi domain support with vhost library.

### DIFF
--- a/example/vhost.js
+++ b/example/vhost.js
@@ -1,0 +1,59 @@
+let express = require("express");
+let bodyParser = require("body-parser");
+let vhost = require('vhost');
+let path = require("path");
+
+app = express();
+
+// domains definition
+let domains = [
+    {
+        domain: "vhost1.apify.dev",
+        controllersPath: "vhost/vhost1"
+    },
+    {
+        domain: "vhost2.apify.dev",
+        controllersPath: "vhost/vhost2"
+    },
+    {
+        domain: "vhost3.apify.dev",
+        controllersPath: "vhost/vhost3"
+    },
+    {
+        domain: /127.0.0.1|localhost/,
+        controllersPath: "vhost/localhost"
+    }
+];
+
+// run autoroutes on each domain, using vhost.
+domains.forEach(function(domain) {
+    let domainApp = express();
+
+    domainApp.use(bodyParser.json());
+    domainApp.use(bodyParser.urlencoded({extended: false}));
+
+    let autoRoutes = require('..')(domainApp);
+    autoRoutes(path.join(__dirname, domain.controllersPath), domain.domain);
+
+    app.use(vhost(domain.domain, domainApp));
+});
+
+// 404
+app.use(function(req, res, next) {
+    var err = new Error();
+    err.status = 404;
+    err.msg = 'Not found';
+    next(err);
+});
+
+// err handler
+app.use(function(err, req, res, next) {
+    console.error(err);
+    res.status(err.status || 500);
+    res.json(err);
+});
+
+// run node vhost.js and visit localhost:8081 in your browser
+console.log('[INFO] Example running at localhost:8081');
+
+app.listen(8081);

--- a/example/vhost/localhost/index.js
+++ b/example/vhost/localhost/index.js
@@ -1,0 +1,5 @@
+exports.get = function (req, res, next) {
+    res.status(200).json({
+        "domain": "localhost"
+    });
+};

--- a/example/vhost/vhost1/index.js
+++ b/example/vhost/vhost1/index.js
@@ -1,0 +1,5 @@
+exports.get = function (req, res, next) {
+    res.status(200).json({
+        "domain": "vhost1.apify.dev"
+    });
+};

--- a/example/vhost/vhost2/index.js
+++ b/example/vhost/vhost2/index.js
@@ -1,0 +1,5 @@
+exports.get = function (req, res, next) {
+    res.status(200).json({
+        "domain": "vhost2.apify.dev"
+    });
+};

--- a/example/vhost/vhost3/index.js
+++ b/example/vhost/vhost3/index.js
@@ -1,0 +1,5 @@
+exports.get = function (req, res, next) {
+    res.status(200).json({
+        "domain": "vhost3.apify.dev"
+    });
+};

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var getFileMapCol = require('./lib/getFileMapCol'),
 module.exports = function (app) {
   var mountToApp = new MountToApp(app);
 
-  return function (pathToCtrlDir) {
+  return function (pathToCtrlDir, domain = /localhost|127.0.0.1/) {
     // a sorted collection contains maps of url(mount path) => pathToFile
     // why it must be sorted? turn to the end of lib/mountToApp.js for more detail
     var ctrlCol = getFileMapCol(pathToCtrlDir);
@@ -84,7 +84,7 @@ module.exports = function (app) {
           return;
         }
 
-        mountToApp.mount(_method, config);
+        mountToApp.mount(domain, _method, config);
       }
     });
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,12 @@ var getFileMapCol = require('./lib/getFileMapCol'),
 module.exports = function (app) {
   var mountToApp = new MountToApp(app);
 
-  return function (pathToCtrlDir, domain = /localhost|127.0.0.1/) {
+  return function (pathToCtrlDir, domain = "localhost") {
+    // aliasing localhost
+    if(domain === "127.0.0.1") {
+      domain = "localhost|127.0.0.1";
+    }
+
     // a sorted collection contains maps of url(mount path) => pathToFile
     // why it must be sorted? turn to the end of lib/mountToApp.js for more detail
     var ctrlCol = getFileMapCol(pathToCtrlDir);

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function (app) {
   return function (pathToCtrlDir, domain = "localhost") {
     // aliasing localhost
     if(domain === "127.0.0.1") {
-      domain = "localhost|127.0.0.1";
+      domain = "localhost";
     }
 
     // a sorted collection contains maps of url(mount path) => pathToFile

--- a/index.js
+++ b/index.js
@@ -7,12 +7,7 @@ var getFileMapCol = require('./lib/getFileMapCol'),
 module.exports = function (app) {
   var mountToApp = new MountToApp(app);
 
-  return function (pathToCtrlDir, domain = "localhost") {
-    // aliasing localhost
-    if(domain === "127.0.0.1") {
-      domain = "localhost";
-    }
-
+  return function (pathToCtrlDir, domain = /localhost|127.0.0.1/) {
     // a sorted collection contains maps of url(mount path) => pathToFile
     // why it must be sorted? turn to the end of lib/mountToApp.js for more detail
     var ctrlCol = getFileMapCol(pathToCtrlDir);

--- a/lib/getFileMapCol.js
+++ b/lib/getFileMapCol.js
@@ -2,8 +2,7 @@ var traverseDir = require('./utils/traverseDir'),
   jsExtReg = /\.(ts|js)$/,
   indexReg = /index$/,
   endWithSlashReg = /[\/|\\]$/,
-  fileMap = {},
-  fileMapCol = [];
+  fileMap = {};
 
 /**
  * get a collection of file maps in the given dir
@@ -11,6 +10,8 @@ var traverseDir = require('./utils/traverseDir'),
  * @return {Array} a sorted collection
  */
 module.exports = function (pathToCtrlDir) {
+  let fileMapCol = [];
+
   // clear the last slash
   if (endWithSlashReg.test(pathToCtrlDir)) {
     pathToCtrlDir = pathToCtrlDir.replace(endWithSlashReg, '');

--- a/lib/mountToApp.js
+++ b/lib/mountToApp.js
@@ -7,7 +7,7 @@ function MountToApp(app) {
   this.ordinaryRoutes = [];
 }
 
-MountToApp.prototype.mount = function (method, config) {
+MountToApp.prototype.mount = function (domain, method, config) {
   var mountMap = {}, // mountPath(url) => {Function} route launcher
     mountPath = config[0];
 
@@ -16,7 +16,7 @@ MountToApp.prototype.mount = function (method, config) {
 
     // logger
     if (this.app.get('env') === 'development') {
-      console.info('[AutoMount]', method, mountPath);
+      console.info('[AutoMount]', domain, method, mountPath);
     }
   }.bind(this);
 

--- a/lib/utils/traverseDir.js
+++ b/lib/utils/traverseDir.js
@@ -28,9 +28,9 @@ function getContentOfDir(pathToDir) {
  * @param  {String} baseDir
  * @return {Array}
  */
-var files = [];
 
 function traverseDir(baseDir) {
+  var files = [];
 
   var contents = getContentOfDir(baseDir);
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "async": "^2.0.1",
     "chai": "^3.5.0",
     "express": "^4.14.0",
-    "istanbul": "^0.4.4",
+    "istanbul": "^1.1.0-alpha.1",
     "mocha": "^2.5.3",
     "supertest": "^1.2.0",
     "vhost": "^3.0.2"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "example": "node example/app.js",
+    "vhost": "node example/vhost.js",
     "test": "mocha test/ --recursive",
     "travis": "istanbul cover _mocha"
   },
@@ -30,6 +31,7 @@
     "express": "^4.14.0",
     "istanbul": "^0.4.4",
     "mocha": "^2.5.3",
-    "supertest": "^1.2.0"
+    "supertest": "^1.2.0",
+    "vhost": "^3.0.2"
   }
 }


### PR DESCRIPTION
Hi Ken,

I have been using express-auto-routes for some of my projects. It helps me a lot in my works, thanks for developing a really useful stuff. 

Recently, i am developing a kind of project setup for API development where the main purpose is to ease development of API for developer. Some of the features are providing **simulation of responses for quick frontend prototyping** and **multi domain support**. I am using your express-auto-routes for providing path auto routes.

Your auto routes is working with express vhost actually. But there are some changes where i must do to get it get along nicely with vhost library.

I created this pull request for you to review. I have created examples of vhost auto routes setup on /example/vhost.js. I hope my changes can contribute some improvement to your nice library.

Best Regards